### PR TITLE
actually show windown when running the application

### DIFF
--- a/tcontainer.py
+++ b/tcontainer.py
@@ -278,4 +278,5 @@ class MainWindow(QMainWindow):
 if __name__ == '__main__':
     app = QApplication(sys.argv)
     ex = MainWindow()
+    ex.show()
     sys.exit(app.exec_())


### PR DESCRIPTION
Add `ex.show()` so the application window actually appears when running `python tcontainer.py`